### PR TITLE
Add support for DuckDuckGo

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,20 +1,23 @@
-import { redirectFromFandom, redirectFromGoogle, redirectFromDdg } from "./redirects.js"
+import { redirectFromFandom, searchQueryFromRequest } from "./redirects.js"
 
 // Any requests beginning with these patterns get intercepted.
 const fandomPattern = "https://pathofexile.fandom.com/wiki/*"
-// These Google patterns are written this way to prevent recursively matching on the redirect destination.
-// Redirects will be generated to `/search?q=site:poewiki.net`, 
+// These Search Engine patterns are written this way to prevent recursively matching on the redirect destination.
+// Redirects will be generated to include `?q=site:poewiki.net`, 
 // which a naive pattern of `q=*poe*wiki*` will again match (recursively) and continue trying to redirect for (bad).
-const googlePatterns = [
+const searchEnginePatterns = [
+    //Google
     "https://*.google.com/search?*q=*poe+*wiki*",
     "https://*.google.com/search?*q=*poewiki+*",
-    "https://*.google.com/search?*q=*+poewiki*"
-]
+    "https://*.google.com/search?*q=*+poewiki*",
 
-const duckduckgoPatterns = [
+    //DuckDuckGo
     "https://duckduckgo.com/?*q=*poe+*wiki*",
     "https://duckduckgo.com/?*q=*poewiki+*",
-    "https://duckduckgo.com/?*q=*+poewiki*"
+    "https://duckduckgo.com/?*q=*+poewiki*",
+    "https://*.duckduckgo.com/?*q=*poe+*wiki*",
+    "https://*.duckduckgo.com/?*q=*poewiki+*",
+    "https://*.duckduckgo.com/?*q=*+poewiki*"
 ]
 
 // Instruction for the browser to redirect based on pattern.
@@ -29,17 +32,9 @@ chrome.webRequest.onBeforeRequest.addListener(
 )
 
 chrome.webRequest.onBeforeRequest.addListener(
-    redirectFromGoogle,
+    searchQueryFromRequest,
     {
-        urls: googlePatterns,
-    },
-    ["blocking"],
-)
-
-chrome.webRequest.onBeforeRequest.addListener(
-    redirectFromDdg,
-    {
-        urls: duckduckgoPatterns,
+        urls: searchEnginePatterns,
     },
     ["blocking"],
 )

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,17 +1,19 @@
-import { redirectFromFandom, searchQueryFromRequest } from "./redirects.js"
+import { redirectFromFandom, redirectFromSearchEngine } from "./redirects.js"
 
 // Any requests beginning with these patterns get intercepted.
 const fandomPattern = "https://pathofexile.fandom.com/wiki/*"
 // These Search Engine patterns are written this way to prevent recursively matching on the redirect destination.
 // Redirects will be generated to include `?q=site:poewiki.net`, 
 // which a naive pattern of `q=*poe*wiki*` will again match (recursively) and continue trying to redirect for (bad).
-const searchEnginePatterns = [
-    //Google
+
+// Search engine patterns
+const googlePatterns = [
     "https://*.google.com/search?*q=*poe+*wiki*",
     "https://*.google.com/search?*q=*poewiki+*",
-    "https://*.google.com/search?*q=*+poewiki*",
+    "https://*.google.com/search?*q=*+poewiki*"
+]
 
-    //DuckDuckGo
+const duckduckgoPatterns = [
     "https://duckduckgo.com/?*q=*poe+*wiki*",
     "https://duckduckgo.com/?*q=*poewiki+*",
     "https://duckduckgo.com/?*q=*+poewiki*",
@@ -32,9 +34,9 @@ chrome.webRequest.onBeforeRequest.addListener(
 )
 
 chrome.webRequest.onBeforeRequest.addListener(
-    searchQueryFromRequest,
+    redirectFromSearchEngine,
     {
-        urls: searchEnginePatterns,
+        urls: [...googlePatterns, ...duckduckgoPatterns],
     },
     ["blocking"],
 )

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,8 +1,9 @@
-import { redirectFromFandom, redirectFromGoogle } from "./redirects.js"
+import { redirectFromFandom, redirectFromGoogle, redirectFromDdg } from "./redirects.js"
 
 // Any requests beginning with these patterns get intercepted.
 const fandomPattern = "https://pathofexile.fandom.com/wiki/*"
 const googlePattern = "https://*.google.com/search?*q=poe+*"
+const duckduckgoPattern = "https://duckduckgo.com/?*q=poe+*"
 
 // Instruction for the browser to redirect based on pattern.
 // `chrome` used instead of `browser` for compat since Firefox supports
@@ -19,6 +20,14 @@ chrome.webRequest.onBeforeRequest.addListener(
     redirectFromGoogle,
     {
         urls: [googlePattern],
+    },
+    ["blocking"],
+)
+
+chrome.webRequest.onBeforeRequest.addListener(
+    redirectFromDdg,
+    {
+        urls: [duckduckgoPattern],
     },
     ["blocking"],
 )

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -11,7 +11,11 @@ const googlePatterns = [
     "https://*.google.com/search?*q=*+poewiki*"
 ]
 
-const duckduckgoPattern = "https://duckduckgo.com/?*q=poe+*"
+const duckduckgoPatterns = [
+    "https://duckduckgo.com/?*q=*poe+*wiki*",
+    "https://duckduckgo.com/?*q=*poewiki+*",
+    "https://duckduckgo.com/?*q=*+poewiki*"
+]
 
 // Instruction for the browser to redirect based on pattern.
 // `chrome` used instead of `browser` for compat since Firefox supports
@@ -35,7 +39,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 chrome.webRequest.onBeforeRequest.addListener(
     redirectFromDdg,
     {
-        urls: [duckduckgoPattern],
+        urls: duckduckgoPatterns,
     },
     ["blocking"],
 )

--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -35,6 +35,7 @@ function redirectFromSearchEngine(requestDetails) {
         case "www.duckduckgo.com":
             searchEngine = 'https://www.duckduckgo.com/?q=site:poewiki.net+'
             break;
+        default: searchEngine = 'https://www.duckduckgo.com/?q=site:poewiki.net+'
     }
     const redirectResult = searchEngine + searchQuery
 

--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -13,10 +13,9 @@ function redirectFromFandom(requestDetails) {
     }
 }
 
-// When we are making a Google search containing the words "poe", "wiki" or "poewiki",
+// When we are making a search query containing the words "poe", "wiki" or "poewiki",
 // this function will prepend "site:poewiki.net" to the search, filtering out "poe", "wiki" and "poewiki".
-function redirectFromGoogle(requestDetails) {
-    // Grab the search query itself and remove the "poe " at the beginning
+function searchQueryFromRequest(requestDetails) {
     const url = new URL(requestDetails.url)
     const searchQuery = url.searchParams
         .get("q")
@@ -25,22 +24,25 @@ function redirectFromGoogle(requestDetails) {
         .filter(qParam => qParam !== "" && !["poe", "wiki", "poewiki"].includes(qParam))
         .join("+")
 
+    let searchEngine = null;
+
+    switch (url.host) {
+        case "google.com":
+        case "www.google.com":
+            searchEngine = 'https://www.google.com/search?q=site:poewiki.net+'
+            break;
+        case "duckduckgo.com":
+        case "www.duckduckgo.com":
+            searchEngine = 'https://www.duckduckgo.com/?q=site:poewiki.net+'
+            break;
+    }
+    const redirectResult = searchEngine + searchQuery
+
     // Return the redirect url with "site:poewiki.net" prepended to the search query
     return {
-        redirectUrl: `https://www.google.com/search?q=site:poewiki.net+${searchQuery}`,
+        redirectUrl: redirectResult
     }
+
 }
 
-function redirectFromDdg(requestDetails) {
-    const url = new URL(requestDetails.url)
-    const searchQuery = url.searchParams
-        .get("q")
-        .replace(/ /g, "+")
-        .replace(/^poe\+/, "")
-
-    return {
-        redirectUrl: `https://www.duckduckgo.com/?q=site:poewiki.net+${searchQuery}`,
-    }
-}
-
-export { redirectFromFandom, redirectFromGoogle, redirectFromDdg }
+export { redirectFromFandom, searchQueryFromRequest }

--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -35,7 +35,7 @@ function redirectFromDdg(requestDetails) {
         .get("q")
         .replace(/ /g, "+")
         .replace(/^poe\+/, "")
-        
+
     return {
         redirectUrl: `https://www.duckduckgo.com/?q=site:poewiki.net+${searchQuery}`,
     }

--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -29,4 +29,16 @@ function redirectFromGoogle(requestDetails) {
     }
 }
 
-export { redirectFromFandom, redirectFromGoogle }
+function redirectFromDdg(requestDetails) {
+    const url = new URL(requestDetails.url)
+    const searchQuery = url.searchParams
+        .get("q")
+        .replace(/ /g, "+")
+        .replace(/^poe\+/, "")
+        
+    return {
+        redirectUrl: `https://www.duckduckgo.com/?q=site:poewiki.net+${searchQuery}`,
+    }
+}
+
+export { redirectFromFandom, redirectFromGoogle, redirectFromDdg }

--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -15,7 +15,7 @@ function redirectFromFandom(requestDetails) {
 
 // When we are making a search query containing the words "poe", "wiki" or "poewiki",
 // this function will prepend "site:poewiki.net" to the search, filtering out "poe", "wiki" and "poewiki".
-function searchQueryFromRequest(requestDetails) {
+function redirectFromSearchEngine(requestDetails) {
     const url = new URL(requestDetails.url)
     const searchQuery = url.searchParams
         .get("q")
@@ -45,4 +45,4 @@ function searchQueryFromRequest(requestDetails) {
 
 }
 
-export { redirectFromFandom, searchQueryFromRequest }
+export { redirectFromFandom, redirectFromSearchEngine }

--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -24,18 +24,13 @@ function redirectFromSearchEngine(requestDetails) {
         .filter(qParam => qParam !== "" && !["poe", "wiki", "poewiki"].includes(qParam))
         .join("+")
 
-    let searchEngine = null;
+    let searchEngine = 'https://www.google.com/search?q=site:poewiki.net+';
 
     switch (url.host) {
-        case "google.com":
-        case "www.google.com":
-            searchEngine = 'https://www.google.com/search?q=site:poewiki.net+'
-            break;
         case "duckduckgo.com":
         case "www.duckduckgo.com":
             searchEngine = 'https://www.duckduckgo.com/?q=site:poewiki.net+'
             break;
-        default: searchEngine = 'https://www.duckduckgo.com/?q=site:poewiki.net+'
     }
     const redirectResult = searchEngine + searchQuery
 

--- a/src/background/redirects.spec.js
+++ b/src/background/redirects.spec.js
@@ -1,4 +1,4 @@
-import { redirectFromFandom, redirectFromGoogle, redirectFromDdg } from "./redirects.js"
+import { redirectFromFandom, searchQueryFromRequest } from "./redirects.js"
 
 describe("Fandom redirect", () => {
     it.each([
@@ -74,7 +74,7 @@ describe("Google Search redirect", () => {
             expected: "https://www.google.com/search?q=site:poewiki.net+apoe+poea+apoea+awiki+wikia+awikia+apoewiki+poewikia+apoewikia+poeawiki",
         },
     ])("Given $url, redirect to $expected", ({ url, expected }) => {
-        const actual = redirectFromGoogle({ url })
+        const actual = searchQueryFromRequest({ url })
         expect(actual.redirectUrl).toBe(expected)
     })
 })
@@ -98,7 +98,7 @@ describe("DuckDuckGo Search redirect", () => {
             expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
         },
     ])("Given $url, redirect to $expected", ({ url, expected }) => {
-        const actual = redirectFromDdg({ url })
+        const actual = searchQueryFromRequest({ url })
         expect(actual.redirectUrl).toBe(expected)
     })
 })

--- a/src/background/redirects.spec.js
+++ b/src/background/redirects.spec.js
@@ -1,4 +1,4 @@
-import { redirectFromFandom, searchQueryFromRequest } from "./redirects.js"
+import { redirectFromFandom, redirectFromSearchEngine } from "./redirects.js"
 
 describe("Fandom redirect", () => {
     it.each([
@@ -21,10 +21,10 @@ describe("Fandom redirect", () => {
 })
 
 describe("Test queries against all Search Engines redirect", () => {
-    //Setup different Search Engine urls to test against
+    // Setup different Search Engine urls to test against
     const googleUrls = [
-        "https://www.google.com/search?",
         "https://google.com/search?",
+        "https://www.google.com/search?"
     ]
 
     const duckduckgoUrls = [
@@ -32,71 +32,74 @@ describe("Test queries against all Search Engines redirect", () => {
         "https://www.duckduckgo.com/?"
     ]
 
-    //The base redirect result URL to expect from each search engine
-    const redirectHost = new Map()
-    redirectHost.set("google", "https://www.google.com/search?q=site:poewiki.net+")
-    redirectHost.set("duckduckgo", "https://www.duckduckgo.com/?q=site:poewiki.net+")
+    // The base redirect result URL to expect from each search engine
+    const redirectBaseUrls = {
+        google: "https://www.google.com/search?q=site:poewiki.net+",
+        duckduckgo: "https://www.duckduckgo.com/?q=site:poewiki.net+"
+    }
 
-    //Run the tests for a given search engine
+    // Run the tests for a given search engine
     runTestQueries(googleUrls, "google")
     runTestQueries(duckduckgoUrls, "duckduckgo")
 
     function runTestQueries(urlCollection, searchEngine) {
-        urlCollection.forEach(urlHost =>
+        const redirectBaseUrl = redirectBaseUrls[searchEngine]
+        
+        urlCollection.forEach(baseUrl =>
             it.each([
                 {
-                    url: urlHost + "q=poe+faster+attacks",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks"
+                    url: baseUrl + "q=poe+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks"
                 },
                 // Noisy query parameters cases
                 {
-                    url: urlHost + "client=firefox-b-1-d&q=poewiki+faster+attacks",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "client=firefox-b-1-d&q=poewiki+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=poewiki+faster+attacks&rlz=1CDSA2EA_enUS653US116&oq=poe+test+wiki&aqs=chrome..6213i57j64.1j7&sourceid=chrome&ie=UTF-8",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=poewiki+faster+attacks&rlz=1CDSA2EA_enUS653US116&oq=poe+test+wiki&aqs=chrome..6213i57j64.1j7&sourceid=chrome&ie=UTF-8",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=poewiki+faster+attacks",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=poewiki+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 // Wildcard *poe*wiki* cases
                 {
-                    url: urlHost + "q=poe+wiki+faster+attacks",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=poe+wiki+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=poe++wiki+faster+attacks",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=poe++wiki+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=poe+faster+attacks+wiki",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=poe+faster+attacks+wiki",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=faster+poe+attacks+wiki",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=faster+poe+attacks+wiki",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=faster+attacks+poe+wiki",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=faster+attacks+poe+wiki",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=faster+attacks+poewiki",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=faster+attacks+poewiki",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 {
-                    url: urlHost + "q=faster+poewiki+attacks",
-                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                    url: baseUrl + "q=faster+poewiki+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
                 },
                 // Making sure words that happen to contain "poe", "wiki" or "poewiki" do not get filtered
                 {
-                    url: urlHost + "q=poe+apoe+poea+apoea+awiki+wikia+awikia+wiki+apoewiki+poewikia+apoewikia+poeawiki",
-                    expected: redirectHost.get(searchEngine) + "apoe+poea+apoea+awiki+wikia+awikia+apoewiki+poewikia+apoewikia+poeawiki",
+                    url: baseUrl + "q=poe+apoe+poea+apoea+awiki+wikia+awikia+wiki+apoewiki+poewikia+apoewikia+poeawiki",
+                    expected: redirectBaseUrl + "apoe+poea+apoea+awiki+wikia+awikia+apoewiki+poewikia+apoewikia+poeawiki",
                 },
             ])(searchEngine + " - Given $url, redirect to $expected", ({ url, expected }) => {
-                const actual = searchQueryFromRequest({ url })
+                const actual = redirectFromSearchEngine({ url })
                 expect(actual.redirectUrl).toBe(expected)
             })
         )

--- a/src/background/redirects.spec.js
+++ b/src/background/redirects.spec.js
@@ -44,7 +44,7 @@ describe("Test queries against all Search Engines redirect", () => {
 
     function runTestQueries(urlCollection, searchEngine) {
         const redirectBaseUrl = redirectBaseUrls[searchEngine]
-        
+
         urlCollection.forEach(baseUrl =>
             it.each([
                 {

--- a/src/background/redirects.spec.js
+++ b/src/background/redirects.spec.js
@@ -20,85 +20,85 @@ describe("Fandom redirect", () => {
     })
 })
 
-describe("Google Search redirect", () => {
-    it.each([
-        {
-            url: "https://www.google.com/search?q=poewiki+faster+attacks",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        // Noisy query parameters cases
-        {
-            url: "https://www.google.com/search?client=firefox-b-1-d&q=poewiki+faster+attacks",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=poewiki+faster+attacks&rlz=1CDSA2EA_enUS653US116&oq=poe+test+wiki&aqs=chrome..6213i57j64.1j7&sourceid=chrome&ie=UTF-8",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://google.com/search?q=poewiki+faster+attacks",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        // Wildcard *poe*wiki* cases
-        {
-            url: "https://www.google.com/search?q=poe+wiki+faster+attacks",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=poe++wiki+faster+attacks",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=poe+faster+attacks+wiki",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=faster+poe+attacks+wiki",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=faster+attacks+poe+wiki",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=faster+attacks+poewiki",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://www.google.com/search?q=faster+poewiki+attacks",
-            expected: "https://www.google.com/search?q=site:poewiki.net+faster+attacks",
-        },
-        // Making sure words that happen to contain "poe", "wiki" or "poewiki" do not get filtered
-        {
-            url: "https://www.google.com/search?q=poe+apoe+poea+apoea+awiki+wikia+awikia+wiki+apoewiki+poewikia+apoewikia+poeawiki",
-            expected: "https://www.google.com/search?q=site:poewiki.net+apoe+poea+apoea+awiki+wikia+awikia+apoewiki+poewikia+apoewikia+poeawiki",
-        },
-    ])("Given $url, redirect to $expected", ({ url, expected }) => {
-        const actual = searchQueryFromRequest({ url })
-        expect(actual.redirectUrl).toBe(expected)
-    })
-})
+describe("Test queries against all Search Engines redirect", () => {
+    //Setup different Search Engine urls to test against
+    const googleUrls = [
+        "https://www.google.com/search?",
+        "https://google.com/search?",
+    ]
 
-describe("DuckDuckGo Search redirect", () => {
-    it.each([
-        {
-            url: "https://duckduckgo.com/?q=poe+faster+attacks",
-            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://duckduckgo.com/?client=firefox-b-1-d&q=poe+faster+attacks",
-            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://duckduckgo.com/?q=poe+faster+attacks&rlz=1CDSA2EA_enUS653US116&oq=poe+test+wiki&aqs=chrome..6213i57j64.1j7&sourceid=chrome&ie=UTF-8",
-            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
-        },
-        {
-            url: "https://duckduckgo.com/?q=poe+faster+attacks",
-            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
-        },
-    ])("Given $url, redirect to $expected", ({ url, expected }) => {
-        const actual = searchQueryFromRequest({ url })
-        expect(actual.redirectUrl).toBe(expected)
-    })
+    const duckduckgoUrls = [
+        "https://duckduckgo.com/?",
+        "https://www.duckduckgo.com/?"
+    ]
+
+    //The base redirect result URL to expect from each search engine
+    const redirectHost = new Map()
+    redirectHost.set("google", "https://www.google.com/search?q=site:poewiki.net+")
+    redirectHost.set("duckduckgo", "https://www.duckduckgo.com/?q=site:poewiki.net+")
+
+    //Run the tests for a given search engine
+    runTestQueries(googleUrls, "google")
+    runTestQueries(duckduckgoUrls, "duckduckgo")
+
+    function runTestQueries(urlCollection, searchEngine) {
+        urlCollection.forEach(urlHost =>
+            it.each([
+                {
+                    url: urlHost + "q=poe+faster+attacks",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks"
+                },
+                // Noisy query parameters cases
+                {
+                    url: urlHost + "client=firefox-b-1-d&q=poewiki+faster+attacks",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=poewiki+faster+attacks&rlz=1CDSA2EA_enUS653US116&oq=poe+test+wiki&aqs=chrome..6213i57j64.1j7&sourceid=chrome&ie=UTF-8",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=poewiki+faster+attacks",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                // Wildcard *poe*wiki* cases
+                {
+                    url: urlHost + "q=poe+wiki+faster+attacks",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=poe++wiki+faster+attacks",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=poe+faster+attacks+wiki",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=faster+poe+attacks+wiki",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=faster+attacks+poe+wiki",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=faster+attacks+poewiki",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                {
+                    url: urlHost + "q=faster+poewiki+attacks",
+                    expected: redirectHost.get(searchEngine) + "faster+attacks",
+                },
+                // Making sure words that happen to contain "poe", "wiki" or "poewiki" do not get filtered
+                {
+                    url: urlHost + "q=poe+apoe+poea+apoea+awiki+wikia+awikia+wiki+apoewiki+poewikia+apoewikia+poeawiki",
+                    expected: redirectHost.get(searchEngine) + "apoe+poea+apoea+awiki+wikia+awikia+apoewiki+poewikia+apoewikia+poeawiki",
+                },
+            ])(searchEngine + " - Given $url, redirect to $expected", ({ url, expected }) => {
+                const actual = searchQueryFromRequest({ url })
+                expect(actual.redirectUrl).toBe(expected)
+            })
+        )
+    }
 })

--- a/src/background/redirects.spec.js
+++ b/src/background/redirects.spec.js
@@ -1,4 +1,4 @@
-import { redirectFromFandom, redirectFromGoogle } from "./redirects.js"
+import { redirectFromFandom, redirectFromGoogle, redirectFromDdg } from "./redirects.js"
 
 describe("Fandom redirect", () => {
     it.each([
@@ -40,6 +40,30 @@ describe("Google Search redirect", () => {
         },
     ])("Given $url, redirect to $expected", ({ url, expected }) => {
         const actual = redirectFromGoogle({ url })
+        expect(actual.redirectUrl).toBe(expected)
+    })
+})
+
+describe("DuckDuckGo Search redirect", () => {
+    it.each([
+        {
+            url: "https://duckduckgo.com/?q=poe+faster+attacks",
+            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
+        },
+        {
+            url: "https://duckduckgo.com/?client=firefox-b-1-d&q=poe+faster+attacks",
+            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
+        },
+        {
+            url: "https://duckduckgo.com/?q=poe+faster+attacks&rlz=1CDSA2EA_enUS653US116&oq=poe+test+wiki&aqs=chrome..6213i57j64.1j7&sourceid=chrome&ie=UTF-8",
+            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
+        },
+        {
+            url: "https://duckduckgo.com/?q=poe+faster+attacks",
+            expected: "https://www.duckduckgo.com/?q=site:poewiki.net+faster+attacks",
+        },
+    ])("Given $url, redirect to $expected", ({ url, expected }) => {
+        const actual = redirectFromDdg({ url })
         expect(actual.redirectUrl).toBe(expected)
     })
 })

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,8 @@
         "webRequestBlocking",
         "https://pathofexile.fandom.com/",
         "https://google.com/",
-        "https://www.google.com/"
+        "https://www.google.com/",
+        "https://duckduckgo.com/"
     ],
     "background": {
         "page": "background/background.html"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,8 @@
         "https://pathofexile.fandom.com/",
         "https://google.com/",
         "https://www.google.com/",
-        "https://duckduckgo.com/"
+        "https://duckduckgo.com/",
+        "https://www.duckduckgo.com/"
     ],
     "background": {
         "page": "background/background.html"


### PR DESCRIPTION
Allows for search queries done via [DuckDuckGo](https://duckduckgo.com/) to replace the `poe` keyword with `site:poewiki.net`, extending the existing google functionality to another search engine.

Tested successfully on Mozilla Firefox 91.0.2
