### PR TITLE
Remove special characters, causing infinite redirects

### DIFF
--- a/src/background/redirects.js
+++ b/src/background/redirects.js
@@ -19,6 +19,7 @@ function redirectFromSearchEngine(requestDetails) {
     const url = new URL(requestDetails.url)
     const searchQuery = url.searchParams
         .get("q")
+        .replace(/([",\.']+)/g,"")
         .split(" ")
         // Filter "empty" words (caused from consecutive spaces in the query), and the poewiki words we use to match redirects for.
         .filter(qParam => qParam !== "" && !["poe", "wiki", "poewiki"].includes(qParam))

--- a/src/background/redirects.spec.js
+++ b/src/background/redirects.spec.js
@@ -64,6 +64,19 @@ describe("Test queries against all Search Engines redirect", () => {
                     url: baseUrl + "q=poewiki+faster+attacks",
                     expected: redirectBaseUrl + "faster+attacks",
                 },
+                // Sanitize some special characters
+                {
+                    url: baseUrl + "q=\"poewiki\"+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
+                },
+                {
+                    url: baseUrl + "q=\"poe+wiki\"+faster+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
+                },
+                {
+                    url: baseUrl + "q=\"\poe+\'\.wiki\"+faster\'+attacks",
+                    expected: redirectBaseUrl + "faster+attacks",
+                },
                 // Wildcard *poe*wiki* cases
                 {
                     url: baseUrl + "q=poe+wiki+faster+attacks",


### PR DESCRIPTION
@Vcleal brought up an issue in this comment https://github.com/Project-Path-of-Exile-Wiki/poe-wiki-search/issues/8#issuecomment-947006542

These changes will sanitize the search query a bit, so we avoid the infinite redirect caused by things like `"poe` and `wiki"` plus other combinations.
Characters filtered atm: `"` `,` `.` `'`